### PR TITLE
hapifirmware.ino: Fixed bug in wrapping string with " in it.

### DIFF
--- a/src/dumb_module/arduino/hapifirmware/hapifirmware.ino
+++ b/src/dumb_module/arduino/hapifirmware/hapifirmware.ino
@@ -394,7 +394,7 @@ void assembleResponse(String &responseString, String varName, String value) {
   }
 
   if (!varName.equals(F(""))) {
-    responseString = responseString + F("\")F(" + varName + ")\F("") + F(":") + F("\")F(" + value + ")\F("") + F(",");
+    responseString = responseString + F("\"") + varName + F("\"") + F(":") + F("\"") + value + F("\"") + F(",");
   }
   else {
     if (responseString.endsWith(F(","))) {


### PR DESCRIPTION
This will help your [pull request #100 on mayaculpa](https://github.com/mayaculpa/hapi/pull/100).
I knew that I had fixed this before.
I found it again in my jp-67 branch.

---

Related, but separately and additionally, @ozarchie wrote in
[pull request #97 on mayaculpa](https://github.com/mayaculpa/hapi/pull/97)
that using the F() wrapper is not appropriate is some circumstances.
You should read it and make your own judgement.